### PR TITLE
Updated moment to 2.15.2 which fixes the Regex DoS exploit

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "express-brute": "~0.5.0",
-    "moment": "~2.14.1",
+    "moment": "~2.15.2",
     "mongoose": "~4.5"
   }
 }


### PR DESCRIPTION
The current version of moment listed as a dependency as a Regex DoS security exploit. Updated version to closest one where the issue is fixed (2.15.2).
