### PR TITLE
Deleted _id from update fields

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22,7 +22,6 @@ class MongooseStore extends AbstractClientStore {
     const ret = this.model.update({
       _id: id
     }, {
-      _id: id,
       data: value,
       expires
     }, {


### PR DESCRIPTION
I was getting the error `Cannot increment request count` from `express-brute` when using the Mongoose store and on investigation saw the reason it couldn't increase the count was that Mongoose was throwing the following error when trying to update:

```
{ MongoError: Mod on _id not allowed
    at Function.MongoError.create (/Users/eliotf/Sites/Connections/bbc-connections-v2/node_modules/mongodb-core/lib/error.js:31:11)
    at toError (/Users/eliotf/Sites/Connections/bbc-connections-v2/node_modules/mongodb/lib/utils.js:139:22)
    at /Users/eliotf/Sites/Connections/bbc-connections-v2/node_modules/mongodb/lib/collection.js:1049:60
    at getLastErrorCallback (/Users/eliotf/Sites/Connections/bbc-connections-v2/node_modules/mongodb-core/lib/wireprotocol/2_4_support.js:463:18)
    at /Users/eliotf/Sites/Connections/bbc-connections-v2/node_modules/mongodb-core/lib/connection/pool.js:461:18
    at _combinedTickCallback (internal/process/next_tick.js:67:7)
    at process._tickCallback (internal/process/next_tick.js:98:9)
  name: 'MongoError',
  message: 'Mod on _id not allowed',
  driver: true,
  ok: 1,
  n: 0,
  nModified: 0,
  code: 10148,
  errmsg: 'Mod on _id not allowed',
  writeConcernError: { code: 10148, errmsg: 'Mod on _id not allowed' } }
```

To remedy this I removed the id from the fields it should set.