### PR TITLE
Remove index declaration in brute force schema

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -2,7 +2,7 @@ const mongoose = require('mongoose');
 
 const bruteForceSchema = new mongoose.Schema(
   {
-    _id: { type: String, index: 1 },
+    _id: { type: String },
     data: {
       count: Number,
       lastRequest: Date,


### PR DESCRIPTION
In newer versions of mongoose setting the index on any `_id` field causes an error to occur, as Mongo takes care of indexing `_id` for you.